### PR TITLE
feat: remove Yarn engine check

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,8 +17,7 @@
   "engines": {
     "node": ">=18.0.0",
     "npm": "please use pnpm",
-    "pnpm": ">=6.32.4",
-    "yarn": "please use pnpm"
+    "pnpm": ">=6.32.4"
   },
   "exports": {
     "types": "./dist/index.d.ts",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -25,8 +25,7 @@
   "engines": {
     "node": ">=18.0.0",
     "npm": "please use pnpm",
-    "pnpm": ">=6.32.4",
-    "yarn": "please use pnpm"
+    "pnpm": ">=6.32.4"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
### Problem

Elivagar currently does not use PNPM.

### Solution

Temporarily remove the engine check for Yarn.

### Testing

<!--- Steps on how to test the change -->
