### PR TITLE
Fix undefined bodies

### DIFF
--- a/.changeset/friendly-turkeys-dance.md
+++ b/.changeset/friendly-turkeys-dance.md
@@ -1,0 +1,5 @@
+---
+"@nornir/rest": minor
+---
+
+added AnyMimeType to replace MimeType.None

--- a/.changeset/shy-deers-confess.md
+++ b/.changeset/shy-deers-confess.md
@@ -1,0 +1,5 @@
+---
+"@nornir/rest": patch
+---
+
+fix undefined bodies

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "syncpack": "^9.8.4",
     "ts-patch": "^3.0.2",
     "turbo": "^1.9.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,14 +5,14 @@
   "author": "John Conley",
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@nrfcloud/ts-json-schema-transformer": "^1.2.3",
+    "@nrfcloud/ts-json-schema-transformer": "^1.2.4",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.15.11",
     "esbuild": "^0.17.18",
     "eslint": "^8.45.0",
     "jest": "^29.5.0",
     "ts-patch": "^3.0.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -4,12 +4,12 @@
   "version": "1.2.0",
   "dependencies": {
     "@nornir/core": "workspace:^",
-    "@nrfcloud/ts-json-schema-transformer": "^1.2.3",
+    "@nrfcloud/ts-json-schema-transformer": "^1.2.4",
     "@types/aws-lambda": "^8.10.115",
     "ajv": "^8.12.0",
     "openapi-types": "^12.1.0",
     "trouter": "^3.2.1",
-    "ts-json-schema-generator": "^1.3.0-next.7",
+    "ts-json-schema-generator": "^1.4.0",
     "ts-morph": "^19.0.0",
     "tsutils": "^3.21.0"
   },
@@ -20,7 +20,7 @@
     "eslint": "^8.45.0",
     "jest": "^29.5.0",
     "ts-patch": "^3.0.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/rest/src/runtime/http-event.mts
+++ b/packages/rest/src/runtime/http-event.mts
@@ -56,6 +56,9 @@ export interface SerializedHttpResponse extends Omit<HttpResponse, "body"> {
 }
 
 export interface HttpResponseEmpty extends HttpResponse {
+    headers: {
+        "content-type": MimeType.None;
+    },
     body?: never;
 }
 

--- a/packages/rest/src/runtime/http-event.mts
+++ b/packages/rest/src/runtime/http-event.mts
@@ -131,6 +131,7 @@ export type AnyMimeType = Nominal<string | undefined, "AnyMimeType">
 export const AnyMimeType = "*/*" as AnyMimeType;
 
 export enum MimeType {
+    None = "",
     ApplicationJson = "application/json",
     ApplicationOctetStream = "application/octet-stream",
     ApplicationPdf = "application/pdf",

--- a/packages/rest/src/runtime/http-event.mts
+++ b/packages/rest/src/runtime/http-event.mts
@@ -1,3 +1,5 @@
+import {Nominal} from "./utils.mjs";
+
 export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD" | "OPTIONS";
 
 export type HttpEvent = Omit<HttpRequest, "pathParams" | "headers"> & {
@@ -16,8 +18,9 @@ export type UnparsedHttpEvent = Omit<HttpEvent, "body" | "query"> & {
 // } & Record<string, string | number>
 
 export type HttpHeadersWithContentType = {
-    readonly "content-type": MimeType;
+    readonly "content-type": MimeType | AnyMimeType
 } & HttpHeaders;
+
 
 export type HttpHeaders = Record<string, number | string>;
 
@@ -33,9 +36,9 @@ export interface HttpRequest {
 
 export interface HttpRequestEmpty extends HttpRequest {
     headers: {
-        "content-type": MimeType.None;
+        "content-type": AnyMimeType;
     }
-    body: never;
+    // body?: undefined;
 }
 
 export interface HttpRequestJSON extends HttpRequest {
@@ -57,9 +60,9 @@ export interface SerializedHttpResponse extends Omit<HttpResponse, "body"> {
 
 export interface HttpResponseEmpty extends HttpResponse {
     headers: {
-        "content-type": MimeType.None;
+        "content-type": AnyMimeType;
     },
-    body?: never;
+    body?: undefined;
 }
 
 export enum HttpStatusCode {
@@ -124,8 +127,10 @@ export enum HttpStatusCode {
     NotExtended = "510",
 }
 
+export type AnyMimeType = Nominal<string | undefined, "AnyMimeType">
+export const AnyMimeType = "*/*" as AnyMimeType;
+
 export enum MimeType {
-    None = "",
     ApplicationJson = "application/json",
     ApplicationOctetStream = "application/octet-stream",
     ApplicationPdf = "application/pdf",
@@ -156,6 +161,4 @@ export enum MimeType {
     VideoXMsVideo = "video/x-msvideo",
     VideoXFlv = "video/x-flv",
     VideoWebm = "video/webm",
-
-
 }

--- a/packages/rest/src/runtime/index.mts
+++ b/packages/rest/src/runtime/index.mts
@@ -7,7 +7,7 @@ export {
 export {
     HttpResponse, HttpRequest, HttpEvent, HttpMethod, HttpRequestEmpty, HttpResponseEmpty,
     HttpStatusCode, HttpRequestJSON, HttpHeaders, MimeType,
-    UnparsedHttpEvent, SerializedHttpResponse
+    UnparsedHttpEvent, SerializedHttpResponse, AnyMimeType
 } from './http-event.mjs';
 export {RouteHolder, NornirRestRequestValidationError} from './route-holder.mjs'
 export {NornirRestRequestError, NornirRestError, httpErrorHandler, mapError, mapErrorClass} from './error.mjs'

--- a/packages/rest/src/runtime/router.mts
+++ b/packages/rest/src/runtime/router.mts
@@ -1,6 +1,14 @@
 import Trouter from 'trouter';
 import {RouteBuilder, RouteHolder} from './route-holder.mjs';
-import {HttpEvent, HttpMethod, HttpRequest, HttpResponse, HttpStatusCode, MimeType} from './http-event.mjs';
+import {
+    HttpEvent,
+    HttpHeadersWithContentType,
+    HttpMethod,
+    HttpRequest,
+    HttpResponse,
+    HttpStatusCode,
+    MimeType
+} from './http-event.mjs';
 import {AttachmentRegistry, Nornir, Result} from '@nornir/core';
 import {NornirRestRequestError} from "./error.mjs";
 
@@ -60,9 +68,9 @@ export class Router {
             const request: HttpRequest = {
                 ...event,
                 headers: {
-                    "content-type": MimeType.None,
+                    "content-type": "" as never,
                     ...event.headers,
-                },
+                } as HttpHeadersWithContentType,
                 pathParams: params,
             }
             if (handler == undefined) {

--- a/packages/rest/src/runtime/serialize.mts
+++ b/packages/rest/src/runtime/serialize.mts
@@ -7,9 +7,9 @@ export type HttpBodySerializer<T> = (body: T | undefined) => Buffer
 export type HttpBodySerializerMap = Partial<Record<MimeType | "default", HttpBodySerializer<never>>>
 
 const DEFAULT_BODY_SERIALIZERS: HttpBodySerializerMap & {default: HttpBodySerializer<never>} = {
-    "application/json": (body?: object) => Buffer.from(JSON.stringify(body), "utf8"),
+    "application/json": (body?: object) => Buffer.from(JSON.stringify(body) || "", "utf8"),
     "text/plain": (body?: string) => Buffer.from(body?.toString() || "", "utf8"),
-    "default": (body?: never) => Buffer.from(JSON.stringify(body), "utf8")
+    "default": (body?: never) => Buffer.from(JSON.stringify(body) || "", "utf8")
 }
 
 export function httpResponseSerializer(bodySerializerMap?: HttpBodySerializerMap) {

--- a/packages/rest/src/runtime/utils.mts
+++ b/packages/rest/src/runtime/utils.mts
@@ -23,3 +23,15 @@ export function normalizeHeaders(headers: HttpHeaders): HttpHeaders {
         ...lowercaseHeaders
     }
 }
+
+/**
+ * @internal
+ */
+export declare class Tagged<N extends string> {
+    protected _nominal_: N;
+}
+
+/**
+ * @internal
+ */
+export type Nominal<T, N extends string, E extends T & Tagged<string> = T & Tagged<N>> = (T & Tagged<N>) | E;

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@nrfcloud/ts-json-schema-transformer": "^1.2.3",
+    "@nrfcloud/ts-json-schema-transformer": "^1.2.4",
     "@types/aws-lambda": "^8.10.115",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.15.11",
@@ -16,7 +16,7 @@
     "eslint": "^8.45.0",
     "jest": "^29.5.0",
     "ts-patch": "^3.0.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/test/src/controller.ts
+++ b/packages/test/src/controller.ts
@@ -1,5 +1,6 @@
 import { Nornir } from "@nornir/core";
 import {
+  AnyMimeType,
   Controller,
   GetChain,
   type HttpRequest,
@@ -13,7 +14,7 @@ import { assertValid } from "@nrfcloud/ts-json-schema-transformer";
 interface RouteGetInput extends HttpRequestEmpty {
   headers: {
     // eslint-disable-next-line sonarjs/no-duplicate-string
-    "content-type": MimeType.None;
+    "content-type": AnyMimeType;
   };
 }
 

--- a/packages/test/src/controller2.ts
+++ b/packages/test/src/controller2.ts
@@ -1,5 +1,6 @@
 import { Nornir } from "@nornir/core";
 import {
+  AnyMimeType,
   Controller,
   GetChain,
   HttpRequest,
@@ -16,7 +17,7 @@ interface RouteGetInput extends HttpRequestEmpty {
   headers: GetHeaders;
 }
 interface GetHeaders {
-  "content-type": MimeType.None;
+  "content-type": AnyMimeType;
   [key: string]: string;
 }
 
@@ -72,7 +73,7 @@ export class TestController {
       .use(() => ({
         statusCode: HttpStatusCode.Created,
         headers: {
-          "content-type": MimeType.TextPlain,
+          "content-type": AnyMimeType,
         },
       }));
   }

--- a/packages/test/src/rest.ts
+++ b/packages/test/src/rest.ts
@@ -1,5 +1,6 @@
-import nornir, { AttachmentRegistry } from "@nornir/core";
+import nornir from "@nornir/core";
 import {
+  AnyMimeType,
   ApiGatewayProxyV2,
   httpErrorHandler,
   httpEventParser,
@@ -39,7 +40,7 @@ const frameworkChain = nornir<UnparsedHttpEvent>()
     mapErrorClass(TestError, err => ({
       statusCode: HttpStatusCode.InternalServerError,
       headers: {
-        "content-type": MimeType.None,
+        "content-type": AnyMimeType,
       },
     })),
   ]))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
         version: 18.15.11
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.2.0
-        version: 6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.45.0)(typescript@5.1.6)
+        version: 6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.45.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: ^6.2.0
-        version: 6.2.0(eslint@8.45.0)(typescript@5.1.6)
+        version: 6.2.0(eslint@8.45.0)(typescript@5.2.2)
       dprint:
         specifier: ^0.34.5
         version: 0.34.5
@@ -52,7 +52,7 @@ importers:
         version: 3.2.0(eslint@8.45.0)
       eslint-plugin-jest:
         specifier: ^27.2.3
-        version: 27.2.3(@typescript-eslint/eslint-plugin@6.2.0)(eslint@8.45.0)(jest@29.5.0)(typescript@5.1.6)
+        version: 27.2.3(@typescript-eslint/eslint-plugin@6.2.0)(eslint@8.45.0)(jest@29.5.0)(typescript@5.2.2)
       eslint-plugin-no-secrets:
         specifier: ^0.8.9
         version: 0.8.9(eslint@8.45.0)
@@ -93,8 +93,8 @@ importers:
         specifier: ^1.9.2
         version: 1.9.2
       typescript:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
 
   packages/core:
     devDependencies:
@@ -102,8 +102,8 @@ importers:
         specifier: ^29.5.0
         version: 29.5.0
       '@nrfcloud/ts-json-schema-transformer':
-        specifier: ^1.2.3
-        version: 1.2.3(typescript@5.1.6)
+        specifier: ^1.2.4
+        version: 1.2.4(typescript@5.2.2)
       '@types/jest':
         specifier: ^29.4.0
         version: 29.4.0
@@ -123,8 +123,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       typescript:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
 
   packages/rest:
     dependencies:
@@ -132,8 +132,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@nrfcloud/ts-json-schema-transformer':
-        specifier: ^1.2.3
-        version: 1.2.3(typescript@5.1.6)
+        specifier: ^1.2.4
+        version: 1.2.4(typescript@5.2.2)
       '@types/aws-lambda':
         specifier: ^8.10.115
         version: 8.10.115
@@ -147,14 +147,14 @@ importers:
         specifier: ^3.2.1
         version: 3.2.1
       ts-json-schema-generator:
-        specifier: ^1.3.0-next.7
-        version: 1.3.0-next.7
+        specifier: ^1.4.0
+        version: 1.4.0
       ts-morph:
         specifier: ^19.0.0
         version: 19.0.0
       tsutils:
         specifier: ^3.21.0
-        version: 3.21.0(typescript@5.1.6)
+        version: 3.21.0(typescript@5.2.2)
     devDependencies:
       '@jest/globals':
         specifier: ^29.5.0
@@ -175,8 +175,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       typescript:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
 
   packages/scripts: {}
 
@@ -193,8 +193,8 @@ importers:
         specifier: ^29.5.0
         version: 29.5.0
       '@nrfcloud/ts-json-schema-transformer':
-        specifier: ^1.2.3
-        version: 1.2.3(typescript@5.1.6)
+        specifier: ^1.2.4
+        version: 1.2.4(typescript@5.2.2)
       '@types/aws-lambda':
         specifier: ^8.10.115
         version: 8.10.115
@@ -217,8 +217,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       typescript:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
 
 packages:
 
@@ -2241,8 +2241,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@nrfcloud/ts-json-schema-transformer@1.2.3(typescript@5.1.6):
-    resolution: {integrity: sha512-0MeZGyp0noARf5P9KV9Du0mrAx5Ofx8qhGkHAHrNaaxnZ6Yim4Vuv/i+s6neMYmZoiExakMRTlLs5PMBqkwpXw==}
+  /@nrfcloud/ts-json-schema-transformer@1.2.4(typescript@5.2.2):
+    resolution: {integrity: sha512-JyZkblORtJCRzE2wOYQC3pIeXjkxg/irNYtC7ufcErCPBB9NHzvqMoAaIPu0bZJdxCLvLKL4qTh7NYpm1gg/Gg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       typescript: '>=5'
@@ -2251,8 +2251,8 @@ packages:
       ajv: 8.12.0
       esbuild: 0.17.18
       json-schema-faker: /@jfconley/json-schema-faker@0.5.0-rcv.48
-      ts-json-schema-generator: 1.3.0-next.7
-      typescript: 5.1.6
+      ts-json-schema-generator: 1.4.0
+      typescript: 5.2.2
 
   /@parcel/source-map@2.1.1:
     resolution: {integrity: sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==}
@@ -2426,7 +2426,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.45.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.45.0)(typescript@5.2.2):
     resolution: {integrity: sha512-rClGrMuyS/3j0ETa1Ui7s6GkLhfZGKZL3ZrChLeAiACBE/tRc1wq8SNZESUuluxhLj9FkUefRs2l6bCIArWBiQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2438,10 +2438,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 6.2.0(eslint@8.45.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.2.0(eslint@8.45.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 6.2.0
-      '@typescript-eslint/type-utils': 6.2.0(eslint@8.45.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.2.0(eslint@8.45.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 6.2.0(eslint@8.45.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.2.0(eslint@8.45.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.2.0
       debug: 4.3.4
       eslint: 8.45.0
@@ -2450,13 +2450,13 @@ packages:
       natural-compare: 1.4.0
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.1(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.1(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.2.0(eslint@8.45.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@6.2.0(eslint@8.45.0)(typescript@5.2.2):
     resolution: {integrity: sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2468,11 +2468,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.2.0
       '@typescript-eslint/types': 6.2.0
-      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.2.0
       debug: 4.3.4
       eslint: 8.45.0
-      typescript: 5.1.6
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2493,7 +2493,7 @@ packages:
       '@typescript-eslint/visitor-keys': 6.2.0
     dev: true
 
-  /@typescript-eslint/type-utils@6.2.0(eslint@8.45.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@6.2.0(eslint@8.45.0)(typescript@5.2.2):
     resolution: {integrity: sha512-DnGZuNU2JN3AYwddYIqrVkYW0uUQdv0AY+kz2M25euVNlujcN2u+rJgfJsBFlUEzBB6OQkUqSZPyuTLf2bP5mw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2503,12 +2503,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.2.0(eslint@8.45.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.2.0(eslint@8.45.0)(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.45.0
-      ts-api-utils: 1.0.1(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.1(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2523,7 +2523,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.2(typescript@5.1.6):
+  /@typescript-eslint/typescript-estree@5.59.2(typescript@5.2.2):
     resolution: {integrity: sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2538,13 +2538,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.2.0(typescript@5.1.6):
+  /@typescript-eslint/typescript-estree@6.2.0(typescript@5.2.2):
     resolution: {integrity: sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2559,13 +2559,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.1(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.1(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.2(eslint@8.45.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@5.59.2(eslint@8.45.0)(typescript@5.2.2):
     resolution: {integrity: sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2576,7 +2576,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.59.2
       '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.2.2)
       eslint: 8.45.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -2585,7 +2585,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.2.0(eslint@8.45.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@6.2.0(eslint@8.45.0)(typescript@5.2.2):
     resolution: {integrity: sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2596,7 +2596,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.2.0
       '@typescript-eslint/types': 6.2.0
-      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.2.2)
       eslint: 8.45.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -3576,7 +3576,7 @@ packages:
       ignore: 5.2.4
     dev: true
 
-  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.2.0)(eslint@8.45.0)(jest@29.5.0)(typescript@5.1.6):
+  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.2.0)(eslint@8.45.0)(jest@29.5.0)(typescript@5.2.2):
     resolution: {integrity: sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -3589,8 +3589,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.45.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.59.2(eslint@8.45.0)(typescript@5.1.6)
+      '@typescript-eslint/eslint-plugin': 6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.45.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.45.0)(typescript@5.2.2)
       eslint: 8.45.0
       jest: 29.5.0(@types/node@18.15.11)
     transitivePeerDependencies:
@@ -6560,17 +6560,17 @@ packages:
       regexparam: 1.3.0
     dev: false
 
-  /ts-api-utils@1.0.1(typescript@5.1.6):
+  /ts-api-utils@1.0.1(typescript@5.2.2):
     resolution: {integrity: sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.1.6
+      typescript: 5.2.2
     dev: true
 
-  /ts-json-schema-generator@1.3.0-next.7:
-    resolution: {integrity: sha512-jCL4T4X1+2oxXCnYeYAJMkC+y/qJQRXKHs7rUOpvdPH8FMXJt+e43v2TLyvZ1/08Qgu46+bWj3AinXMM6nZIuQ==}
+  /ts-json-schema-generator@1.4.0:
+    resolution: {integrity: sha512-wm8vyihmGgYpxrqRshmYkWGNwEk+sf3xV2rUgxv8Ryeh7bSpMO7pZQOht+2rS002eDkFTxR7EwRPXVzrS0WJTg==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     dependencies:
@@ -6580,7 +6580,7 @@ packages:
       json5: 2.2.3
       normalize-path: 3.0.0
       safe-stable-stringify: 2.4.3
-      typescript: 5.1.6
+      typescript: 5.2.2
 
   /ts-morph@19.0.0:
     resolution: {integrity: sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==}
@@ -6608,14 +6608,14 @@ packages:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
-  /tsutils@3.21.0(typescript@5.1.6):
+  /tsutils@3.21.0(typescript@5.2.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.1.6
+      typescript: 5.2.2
 
   /tty-table@4.2.1:
     resolution: {integrity: sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==}
@@ -6767,8 +6767,8 @@ packages:
       is-typed-array: 1.1.12
     dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
 


### PR DESCRIPTION
### Problem

Currently, undefined body objects will throw

Additionally MimeType.None does no allow any mime type, but instead requires that mime type be empty or "".

### Solution

Don't do that

Add `AnyMimeType` to better support a completely unknown mime type

### Testing

`pnpm test`
