### PR TITLE
Support registry and async in toHttpEvent handlers

### DIFF
--- a/packages/rest/src/runtime/error.mts
+++ b/packages/rest/src/runtime/error.mts
@@ -1,12 +1,12 @@
 import {HttpRequest, HttpResponse} from './http-event.mjs';
-import {Result} from "@nornir/core";
+import {AttachmentRegistry, Result} from "@nornir/core";
 
 /**
  * Base error type for exceptions in rest handlers.
  * Can be directly converted into a HTTP response.
  */
 export abstract class NornirRestError extends Error implements NodeJS.ErrnoException {
-    public abstract toHttpResponse(): HttpResponse;
+    public abstract toHttpResponse(registry: AttachmentRegistry): HttpResponse | Promise<HttpResponse>;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public static isNornirRestError(err: any): err is NornirRestError {
@@ -25,18 +25,18 @@ export abstract class NornirRestRequestError<Request extends HttpRequest> extend
         super(message);
     }
 
-    abstract toHttpResponse(): HttpResponse;
+    abstract toHttpResponse(registry: AttachmentRegistry): HttpResponse | Promise<HttpResponse>;
 }
 
 interface ErrorMapping {
     errorMatch(error: unknown): boolean;
-    toHttpResponse(error: unknown): HttpResponse;
+    toHttpResponse(error: unknown, registry: AttachmentRegistry): HttpResponse | Promise<HttpResponse>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function mapErrorClass<T extends NodeJS.ErrnoException, TClass extends new (...args: any) => T>(error: TClass, toHttpResponse: (err: T) => HttpResponse): ErrorMapping;
+export function mapErrorClass<T extends NodeJS.ErrnoException, TClass extends new (...args: any) => T>(error: TClass, toHttpResponse: (err: T, registry: AttachmentRegistry) => HttpResponse | Promise<HttpResponse>): ErrorMapping;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function mapErrorClass<T extends Error, TClass extends new (...args: any) => T>(error: TClass, toHttpResponse: (err: T) => HttpResponse): ErrorMapping {
+export function mapErrorClass<T extends Error, TClass extends new (...args: any) => T>(error: TClass, toHttpResponse: (err: T, registry: AttachmentRegistry) => HttpResponse | Promise<HttpResponse>): ErrorMapping {
     return {
         errorMatch: (err: unknown): err is T => err instanceof error,
         toHttpResponse
@@ -50,19 +50,19 @@ export function mapError<T>(errorMatch: (err: unknown) => err is T, toHttpRespon
     }
 }
 
-export function httpErrorHandler(errorMappings?: ErrorMapping[]): (input: Result<HttpResponse>) => HttpResponse {
+export function httpErrorHandler(errorMappings?: ErrorMapping[]): (input: Result<HttpResponse>, registry: AttachmentRegistry) => Promise<HttpResponse> {
     const defaultedErrorMappings = errorMappings || [];
 
-    return (input: Result<HttpResponse>) => {
+    return async (input: Result<HttpResponse>, registry: AttachmentRegistry) => {
         if (input.isErr) {
             const error = input.error;
             const mapping = defaultedErrorMappings.find(mapping => mapping.errorMatch(error));
             const responseConverter = mapping?.toHttpResponse
             if (responseConverter != undefined) {
-                return responseConverter(error);
+                return responseConverter(error, registry);
             }
             if (NornirRestError.isNornirRestError(error)) {
-                return error.toHttpResponse();
+                return error.toHttpResponse(registry);
             }
         }
         return input.unwrap();

--- a/packages/test/src/rest.ts
+++ b/packages/test/src/rest.ts
@@ -37,7 +37,7 @@ const frameworkChain = nornir<UnparsedHttpEvent>()
   }))
   .use(router())
   .useResult(httpErrorHandler([
-    mapErrorClass(TestError, err => ({
+    mapErrorClass(TestError, (err) => ({
       statusCode: HttpStatusCode.InternalServerError,
       headers: {
         "content-type": AnyMimeType,


### PR DESCRIPTION
### Problem

Need to have access to event registry in toHttpEvent error handler

### Solution

Add it

### Testing
`pnpm test`
