### PR TITLE
feat: add toResultUnencoded

### DIFF
--- a/.changeset/fair-dolphins-lay.md
+++ b/.changeset/fair-dolphins-lay.md
@@ -1,0 +1,5 @@
+---
+"@nornir/rest": minor
+---
+
+Add toResultUnencoded method.

--- a/packages/rest/src/runtime/converters.mts
+++ b/packages/rest/src/runtime/converters.mts
@@ -27,6 +27,15 @@ export abstract class ApiGatewayProxyV2 {
             statusCode: +event.statusCode
         }
     }
+
+    public static toResultUnencoded(event: SerializedHttpResponse): APIGatewayProxyStructuredResultV2 {
+        return {
+            headers: event.headers,
+            body: event.body.toString("utf8"),
+            isBase64Encoded: false,
+            statusCode: +event.statusCode
+        }
+    }
 }
 
 export async function startLocalServer(chain: Nornir<UnparsedHttpEvent, SerializedHttpResponse>, port = 8080) {


### PR DESCRIPTION
### Problem

Need a variation of `toResult` that does not use base64 encoding.

### Solution

Add `toResultUnencoded`.

### Testing

None
