### PR TITLE
handle invalid payloads and content types

### DIFF
--- a/.changeset/purple-crews-shake.md
+++ b/.changeset/purple-crews-shake.md
@@ -1,0 +1,5 @@
+---
+"@nornir/rest": patch
+---
+
+Handle bad content types and invalid payloads

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ concurrency:
   cancel-in-progress: true
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 jobs:
   unit-tests:
     name: Run unit tests for this service

--- a/packages/rest/__tests__/src/parse.spec.mts
+++ b/packages/rest/__tests__/src/parse.spec.mts
@@ -1,0 +1,19 @@
+import {httpEventParser, NornirParseError, UnparsedHttpEvent} from "../../dist/runtime/index.mjs";
+
+describe("Parsing", () => {
+    it("Should throw correct error on failure to parse", () => {
+        const parser = httpEventParser()
+
+        const event: UnparsedHttpEvent = {
+            headers: {
+                "content-type": "application/json"
+            },
+            rawBody: Buffer.from("not json"),
+            method: "GET",
+            path: "/",
+            rawQuery: ""
+        }
+
+        expect(() => parser(event)).toThrow(NornirParseError)
+    })
+})

--- a/packages/rest/src/runtime/error.mts
+++ b/packages/rest/src/runtime/error.mts
@@ -17,7 +17,7 @@ export abstract class NornirRestError extends Error implements NodeJS.ErrnoExcep
 /**
  * Error type for exceptions that require information about the request.
  */
-export abstract class NornirRestRequestError<Request extends HttpRequest> extends NornirRestError {
+export abstract class NornirRestRequestError<Request extends HttpRequest = HttpRequest> extends NornirRestError {
     constructor(
         public readonly request: Request,
         message: string
@@ -27,6 +27,7 @@ export abstract class NornirRestRequestError<Request extends HttpRequest> extend
 
     abstract toHttpResponse(registry: AttachmentRegistry): HttpResponse | Promise<HttpResponse>;
 }
+
 
 interface ErrorMapping {
     errorMatch(error: unknown): boolean;

--- a/packages/rest/src/runtime/index.mts
+++ b/packages/rest/src/runtime/index.mts
@@ -12,7 +12,7 @@ export {
 export {RouteHolder, NornirRestRequestValidationError} from './route-holder.mjs'
 export {NornirRestRequestError, NornirRestError, httpErrorHandler, mapError, mapErrorClass} from './error.mjs'
 export {ApiGatewayProxyV2, startLocalServer} from "./converters.mjs"
-export {httpEventParser, HttpBodyParser, HttpBodyParserMap, HttpQueryStringParser} from "./parse.mjs"
+export {httpEventParser, HttpBodyParser, HttpBodyParserMap, HttpQueryStringParser, NornirParseError} from "./parse.mjs"
 export {httpResponseSerializer, HttpBodySerializer, HttpBodySerializerMap} from "./serialize.mjs"
 export {normalizeEventHeaders, normalizeHeaders, getContentType} from "./utils.mjs"
 export {Router} from "./router.mjs"

--- a/packages/rest/src/runtime/router.mts
+++ b/packages/rest/src/runtime/router.mts
@@ -99,3 +99,4 @@ export class NornirRouteNotFoundError extends NornirRestRequestError<HttpRequest
         }
     }
 }
+


### PR DESCRIPTION
### Problem

Unhelpful error is thrown when request body cannot be parsed using the given content-type

### Solution

Add new `NornirParseError` class which is thrown when body cannot be parsed

closes #11 

### Testing

run normal test suite
