### PR TITLE
fix: fix issue with JSON ref resolver producing duplicate results

### DIFF
--- a/.changeset/lazy-kiwis-buy.md
+++ b/.changeset/lazy-kiwis-buy.md
@@ -1,0 +1,5 @@
+---
+"@nornir/rest": patch
+---
+
+Fix issue with JSON ref resolver producing duplicate results when root component is an array with subcomponents not containing references

--- a/packages/rest/__tests__/src/utils.spec.mts
+++ b/packages/rest/__tests__/src/utils.spec.mts
@@ -32,6 +32,23 @@ describe("utils", () => {
             expect(result).toEqual({name: 'test'});
         });
 
+        // Test case: When the current object is an array and each component does not have a $ref property
+        test("resolves simple array items", () => {
+            // Arrange
+            const items = [{
+                name: "item1"
+            }, {
+                name: "item2"
+            }] as const;
+            const root = { items } as const;
+            // Act
+            const result = simpleSpecResolve(root);
+            // Assert
+            expect(result).toEqual({
+                items: [{ name: "item1" }, { name: "item2" }],
+            });
+        })
+
         // Test case: When the current object is an array
         test('resolves array items', () => {
             // Arrange

--- a/packages/rest/src/runtime/openapi/openapi-router.mts
+++ b/packages/rest/src/runtime/openapi/openapi-router.mts
@@ -245,7 +245,7 @@ export class OpenAPIRouter<
         const trouterInstance = new Trouter<
             (input: Result<OpenAPIHttpRequest>, registry: AttachmentRegistry) => Promise<Result<OpenAPIHttpResponse>>
         >();
-        this.validateRoutes()
+        this.validateRoutes();
 
         for (const {path, method, handler} of this.routes) {
             const chain = new Nornir<OpenAPIHttpRequest>()

--- a/packages/rest/src/runtime/utils.mts
+++ b/packages/rest/src/runtime/utils.mts
@@ -73,14 +73,6 @@ export type DeeplyResolveAllRefsInJsonObject<
         [K in keyof Object]: DeeplyResolveAllRefsInJsonObject<Root, Object[K], ResolverCache>
     } : Object
 
-
-const root = {
-    "a" : { "$ref": "#/b" },
-    "b" : { "$ref": "#/a" }
-} as const;
-
-const test = simpleSpecResolve(root);
-
 export function simpleSpecResolve<
     const Root,
 >(root: Root): DeeplyResolveAllRefsInJsonObject<NoInfer<Root>> {
@@ -101,7 +93,7 @@ function simpleSpecResolveInternal<
         return simpleSpecResolveInternal(root, result, resolveRefInJsonObject(root, current["$ref"]), resolverCache.concat(current["$ref"]));
     }
     if (Array.isArray(current)) {
-        return current.map((value) => simpleSpecResolveInternal(root, result, value, resolverCache));
+        return current.map((value) => simpleSpecResolveInternal(root, {}, value, resolverCache));
     }
     for (const key in current) {
         result[key] = simpleSpecResolveInternal(root, result[key], current[key], resolverCache);


### PR DESCRIPTION
### Problem

When attempting to resolve JSON refs for an array of components of length > 1, and if none of the components have a `ref` property, it effectively overwrites the `result` object with the "current" result over every iteration in the `map` which leads to the final result being an array of duplicates of whatever the last component is.

This becomes an issue when validating an OpenAPI schema with `required = true` parameters because the resulting resolved spec will contain duplicate `required = true` parameters of the same name, which is a schema violation.

### Solution

Pass an empty object to the `simpleSpecResolveInternal` call in the array mapping because we should be generating "new" results per map iteration, not using whatever the previous "result" is.

### Testing

New test added to `utils.spec.mts`
